### PR TITLE
Refactor: Update Generate Documentation page with shadcn/ui

### DIFF
--- a/frontend/src/pages/Generate.tsx
+++ b/frontend/src/pages/Generate.tsx
@@ -1,6 +1,25 @@
 
 import React, { useState } from 'react';
 import { Plus, Settings } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
 
 interface DocumentationSection {
   id: string;
@@ -40,118 +59,124 @@ const Generate = () => {
   return (
     <div className="max-w-4xl mx-auto p-6">
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-2">Generate Documentation</h1>
-        <p className="text-gray-600">Define what you want to include in your documentation</p>
+        <h1 className="text-3xl font-bold text-foreground mb-2">Generate Documentation</h1>
+        <p className="text-muted-foreground">Define what you want to include in your documentation</p>
       </div>
 
-      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 space-y-6">
-        {/* Project Selection */}
-        <div>
-          <label htmlFor="project" className="block text-sm font-medium text-gray-700 mb-2">
-            Select Project
-          </label>
-          <select
-            id="project"
-            value={selectedProject}
-            onChange={(e) => setSelectedProject(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-          >
-            <option value="">Choose a project...</option>
-            {projects.map((project) => (
-              <option key={project} value={project}>
-                {project}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        {/* Documentation Sections */}
-        <div>
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-gray-900">Documentation Sections</h2>
-            <button
-              onClick={addSection}
-              className="flex items-center px-3 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors duration-200"
-            >
-              <Plus className="w-4 h-4 mr-1" />
-              Add Section
-            </button>
+      <Card className="shadow-sm">
+        <CardHeader>
+          <CardTitle>Project Configuration</CardTitle>
+          <CardDescription>Select the project and define the sections for your documentation.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {/* Project Selection */}
+          <div className="space-y-2">
+            <Label htmlFor="project">Select Project</Label>
+            <Select value={selectedProject} onValueChange={setSelectedProject}>
+              <SelectTrigger id="project" className="w-full">
+                <SelectValue placeholder="Choose a project..." />
+              </SelectTrigger>
+              <SelectContent>
+                {projects.map((project) => (
+                  <SelectItem key={project} value={project}>
+                    {project}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
 
-          <div className="space-y-4">
-            {sections.map((section) => (
-              <div key={section.id} className="p-4 border border-gray-200 rounded-lg">
-                <div className="space-y-3">
-                  <input
-                    type="text"
-                    value={section.title}
-                    onChange={(e) => updateSection(section.id, 'title', e.target.value)}
-                    placeholder="Section title (e.g., API Documentation)"
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                  />
-                  <textarea
-                    value={section.description}
-                    onChange={(e) => updateSection(section.id, 'description', e.target.value)}
-                    placeholder="Describe what this section should include..."
-                    rows={3}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
-                  />
-                  <div className="flex justify-end">
-                    <button
-                      onClick={() => removeSection(section.id)}
-                      className="text-sm text-red-600 hover:text-red-700"
-                    >
-                      Remove
-                    </button>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
+          {/* Documentation Sections */}
+          <div>
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold text-foreground">Documentation Sections</h2>
+              <Button onClick={addSection} size="sm">
+                <Plus className="w-4 h-4 mr-1" />
+                Add Section
+              </Button>
+            </div>
 
-        {/* Generation Options */}
-        <div className="border-t pt-6">
-          <div className="flex items-center space-x-4 mb-4">
-            <Settings className="w-5 h-5 text-gray-400" />
-            <h3 className="text-lg font-medium text-gray-900">Generation Options</h3>
+            <div className="space-y-4">
+              {sections.map((section) => (
+                <Card key={section.id} className="shadow-none border">
+                  <CardContent className="space-y-3"> {/* Removed p-4, relying on CardContent default padding */}
+                    <Input
+                      type="text"
+                      value={section.title}
+                      onChange={(e) => updateSection(section.id, 'title', e.target.value)}
+                      placeholder="Section title (e.g., API Documentation)"
+                    />
+                    <Textarea
+                      value={section.description}
+                      onChange={(e) => updateSection(section.id, 'description', e.target.value)}
+                      placeholder="Describe what this section should include..."
+                      rows={3}
+                      className="resize-none"
+                    />
+                    <div className="flex justify-end">
+                      <Button
+                        variant="destructive" // Changed to destructive variant
+                        size="sm"
+                        onClick={() => removeSection(section.id)}
+                        // className="text-red-600 hover:text-red-700" // Removed direct color manipulation
+                      >
+                        Remove
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
           </div>
-          
-          <div className="grid md:grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
-                Documentation Style
-              </label>
-              <select className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent">
-                <option>Technical (Developer-focused)</option>
-                <option>User-friendly (End-user focused)</option>
-                <option>Comprehensive (Both technical and user)</option>
-              </select>
+
+          {/* Generation Options */}
+          <div className="border-t pt-6">
+            <div className="flex items-center space-x-3 mb-4"> {/* Reduced space-x for closer icon-title */}
+              <Settings className="w-5 h-5 text-muted-foreground" /> {/* Increased icon color intensity */}
+              <h3 className="text-base font-medium text-foreground">Generation Options</h3> {/* Adjusted text size */}
             </div>
             
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
-                Detail Level
-              </label>
-              <select className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent">
-                <option>High (Detailed explanations)</option>
-                <option>Medium (Balanced overview)</option>
-                <option>Low (Concise summaries)</option>
-              </select>
+            <div className="grid md:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>Documentation Style</Label>
+                <Select>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Select style..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="technical">Technical (Developer-focused)</SelectItem>
+                    <SelectItem value="user-friendly">User-friendly (End-user focused)</SelectItem>
+                    <SelectItem value="comprehensive">Comprehensive (Both technical and user)</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label>Detail Level</Label>
+                <Select>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Select detail level..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="high">High (Detailed explanations)</SelectItem>
+                    <SelectItem value="medium">Medium (Balanced overview)</SelectItem>
+                    <SelectItem value="low">Low (Concise summaries)</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
             </div>
           </div>
-        </div>
-
-        {/* Generate Button */}
-        <div className="border-t pt-6">
-          <button 
+        </CardContent>
+        <CardFooter className="border-t pt-6">
+          <Button
             disabled={!selectedProject}
-            className="w-full bg-blue-600 text-white py-3 px-4 rounded-lg hover:bg-blue-700 transition-colors duration-200 font-medium disabled:bg-gray-300 disabled:cursor-not-allowed"
+            className="w-full"
+            size="lg" // Made button larger for emphasis
           >
             Generate Documentation
-          </button>
-        </div>
-      </div>
+          </Button>
+        </CardFooter>
+      </Card>
     </div>
   );
 };


### PR DESCRIPTION
I've replaced standard HTML elements (div, select, input, textarea, button, label) in `frontend/src/pages/Generate.tsx` with their corresponding shadcn/ui components (`Card`, `Select`, `Input`, `Textarea`, `Button`, `Label`).

I also updated the styling to align with shadcn/ui principles. This involved removing redundant Tailwind CSS classes and leveraging component props and utility classes for consistent spacing and layout.

I've verified through code review that the functionality of the page, including project selection, adding/removing/updating documentation sections, and generation options, has been preserved.

I've written unit/integration tests for the `Generate` component in `frontend/src/pages/Generate.test.tsx` using React Testing Library. These tests cover initial rendering, project selection, and section manipulation. However, the tests are currently not passing due to Jest environment configuration issues related to Radix UI components. The test code is complete, but the testing environment requires further setup for these tests to execute successfully.